### PR TITLE
fix: eventLoopLagKey should stay <20, prevent NaN metrics

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,11 +60,16 @@ module.exports = function (options, interval) {
 module.exports.Emitter = Emitter
 
 var eventLoopLagKey = 0
-var eventLoopLag = (new Array(20)).map(function () { return 0 })
+var eventLoopLag = []
+var eventLoopLength = 20
+
+while (eventLoopLag.length < eventLoopLength) {
+  eventLoopLag[eventLoopLag.length] = 0
+}
 
 blocked(function (ms) {
   eventLoopLag[eventLoopLagKey] = ms
-  eventLoopLagKey = (eventLoopLagKey + 1) % 20
+  eventLoopLagKey = (eventLoopLagKey + 1) % eventLoopLength
 }, {interval: 200})
 
 function computeLag () {

--- a/index.js
+++ b/index.js
@@ -59,13 +59,12 @@ module.exports = function (options, interval) {
 
 module.exports.Emitter = Emitter
 
-var eventLoopLagKey = -1
+var eventLoopLagKey = 0
 var eventLoopLag = (new Array(20)).map(function () { return 0 })
 
 blocked(function (ms) {
-  eventLoopLagKey++
-  if (eventLoopLagKey > 20) eventLoopLagKey = 0
   eventLoopLag[eventLoopLagKey] = ms
+  eventLoopLagKey = (eventLoopLagKey + 1) % 20
 }, {interval: 200})
 
 function computeLag () {
@@ -101,6 +100,6 @@ function _interval (fn, duration) {
 function metric (em, name, value) {
   em.metric({
     name: name,
-    value: value === undefined ? 1 : value
+    value: (isNaN(value) || value === null) ? 1 : value
   })
 }


### PR DESCRIPTION
I'm pulling a string from an error message in numbat-collector — it looked like a bunch of js.eventloop events failed to batch send to influx because their values were `null`. In poking around this code I spotted a potentially OOB — `eventLoopLagKey` could go up to `20`, which would increase the size of the array. This is an admittedly superstitious fix, though, since I'm pretty sure `blocked` should still be handing numbers to that new array slot. :ghost: