### PR TITLE
feat: added the ability to disable via env var

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,9 +7,25 @@ var procfs = require('procfs-stats')
 
 var DEFAULT_TIMEOUT = 10000
 
+function coalesce (values = []) {
+  const value =  (values instanceof Array)
+    ? values.filter(x => x !== null && x !== undefined)[0]
+    : values
+
+  return Boolean(value)
+}
+
 module.exports = function (options, interval) {
   var emitter
   options = options || {}
+  var disabled = coalesce([options.disabled, process.env.NUMBAT_PROCESS_DISABLED, false])
+
+  // prevent setup if disabled by configuration override
+  if (disabled === true) {
+    const noop = () => {}
+    noop.disabled = true
+    return noop
+  }
 
   if (typeof options.metric === 'function') {
     emitter = options

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var procfs = require('procfs-stats')
 var DEFAULT_TIMEOUT = 10000
 
 function coalesce (values = []) {
-  const value =  (values instanceof Array)
+  var value = (values instanceof Array)
     ? values.filter(x => x !== null && x !== undefined)[0]
     : values
 
@@ -22,7 +22,7 @@ module.exports = function (options, interval) {
 
   // prevent setup if disabled by configuration override
   if (disabled === true) {
-    const noop = () => {}
+    var noop = () => {}
     noop.disabled = true
     return noop
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -152,7 +152,8 @@
       }
     },
     "blocked": {
-      "version": "https://registry.npmjs.org/blocked/-/blocked-1.2.1.tgz",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blocked/-/blocked-1.2.1.tgz",
       "integrity": "sha1-4i7+dnhjxlq4GX9iUpKRBOHsnOI="
     },
     "boom": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Monitor your process with numbat",
   "main": "index.js",
   "scripts": {
+    "lint": "standard",
     "test": "tape test/*.js && standard"
   },
   "repository": {

--- a/test/test.js
+++ b/test/test.js
@@ -38,7 +38,7 @@ test('gathers proc metrics', function (t) {
 })
 
 function tracker () {
-  const metrics = {}
+  var metrics = {}
 
   return {
     handler: function (attrs) {
@@ -50,12 +50,12 @@ function tracker () {
 
 test('should be disabled when options.disabled === true', function (t) {
   process.env.NUMBAT_PROCESS_DISABLED = false
-  const {handler, metrics} = tracker()
-  const stop = numproc({metric: handler, disabled: true}, 500)
+  const track = tracker()
+  const stop = numproc({metric: track.handler, disabled: true}, 500)
   t.ok(stop.disabled === true, 'should be disabled')
 
   setTimeout(function () {
-    t.ok(Object.keys(metrics).length === 0, 'should not collect any metrics when disabled')
+    t.ok(Object.keys(track.metrics).length === 0, 'should not collect any metrics when disabled')
 
     stop()
     t.end()
@@ -64,32 +64,31 @@ test('should be disabled when options.disabled === true', function (t) {
 
 test('should be disabled when NUMBAT_PROCESS_DISABLED === true', function (t) {
   process.env.NUMBAT_PROCESS_DISABLED = true
-  const {handler, metrics} = tracker()
-  const stop = numproc({metric: handler}, 500)
+  const track = tracker()
+  const stop = numproc({metric: track.handler}, 500)
   t.ok(stop.disabled === true, 'should be disabled')
 
   setTimeout(function () {
-    t.ok(Object.keys(metrics).length === 0, 'should not collect any metrics when disabled')
+    t.ok(Object.keys(track.metrics).length === 0, 'should not collect any metrics when disabled')
 
     stop()
     t.end()
   }, 1020)
 })
 
-
 test('should be prefer options.disabled to NUMBAT_PROCESS_DISABLED', function (t) {
   {
     process.env.NUMBAT_PROCESS_DISABLED = false
-    const {handler, metrics} = tracker()
-    const stop = numproc({metric: handler, disabled: true}, 500)
+    const track = tracker()
+    const stop = numproc({metric: track.handler, disabled: true}, 500)
     t.ok(stop.disabled === true, 'should be disabled')
     stop()
   }
 
   {
     process.env.NUMBAT_PROCESS_DISABLED = true
-    const {handler, metrics} = tracker()
-    const stop = numproc({metric: handler, disabled: false}, 500)
+    const track = tracker()
+    const stop = numproc({metric: track.handler, disabled: false}, 500)
     t.ok(stop.disabled === undefined, 'should NOT be disabled')
     stop()
   }


### PR DESCRIPTION
For containerized environments, it is common to have instrumentation on all containers provided by your orchestration software. This makes the metrics contributed by `numbat-process` redundant in some deployments. This change allows simple control over whether `numbat-process` is disabled for a service by means of the `NUMBAT_PROCESS_DISABLED` environment variable.